### PR TITLE
Feat/fix workflow conflict

### DIFF
--- a/.github/workflows/helm-indexer.yaml
+++ b/.github/workflows/helm-indexer.yaml
@@ -29,8 +29,10 @@ jobs:
         git fetch
         yarn install
         node main.js
-        cat index.yaml
+        cat index-temp.yaml
         git checkout gh-pages
+        rm index.yaml
+        mv index-temp.yaml index.yaml
         git add index.yaml
         git commit -m "🤖 update index.yaml"
         git push

--- a/.github/workflows/helm-indexer.yaml
+++ b/.github/workflows/helm-indexer.yaml
@@ -2,7 +2,7 @@ name: Helm Chart Indexer
 
 on:
   schedule:
-    - cron:  '0 0 * * *' # Schedules a re-index every hour
+    - cron:  '0 */12 * * *' # Schedules a re-index every 12 hours
 
 jobs:
 

--- a/main.js
+++ b/main.js
@@ -43,7 +43,7 @@ let chartEntries = {}
 getChartEntries().then(() => {
     const yamlOutput = createYamlOutput()
 
-    fs.writeFileSync("./index.yaml", yamlOutput, "utf8", (err) => {
+    fs.writeFileSync("./index-temp.yaml", yamlOutput, "utf8", (err) => {
         console.log(err)
     })
 })


### PR DESCRIPTION
Fix issue with file conflict when updating `index.yaml` in gh-pages branch.

- Create a temporary index file
- Remove obsolete file
- Rename temp index to remove `temp` suffix